### PR TITLE
fix / 스토리북-path-alias-해결

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
     '@storybook/preset-create-react-app',
   ],
   webpackFinal: async (config) => {
-    config.resolve.plugins.push(new TsconfigPathsPlugin({}));
+    config.resolve.plugins.push(new TsconfigPathsPlugin());
     return config;
   },
   framework: '@storybook/react',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { MuiProvider, GlobalStyle } from '../src/styles';
+import { MuiProvider, GlobalStyle } from '@styles';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
<!-- 
  PR 작성 시 해당 Issue 연결
  PR 이름: Feature/개발-완료-기능
  PR은 선착순 2명이 달면 수정해서 merge 
-->

## ⚙기능
<!-- 기능을 설명해주세요 -->
- 스토리북 path alias 해결

## 📃구현 내용
<!-- 구현 내용을 작성해 주세요 -->
`TsconfigPathsPlugin()` 안의 `{}`가 기본 설정을 오버라이딩해서 생기는 문제였습니다.

**전**
```js
  webpackFinal: async (config) => {
    config.resolve.plugins.push(new TsconfigPathsPlugin({}));
    return config;
  },
```

**후**
```js
  webpackFinal: async (config) => {
    config.resolve.plugins.push(new TsconfigPathsPlugin());
    return config;
  },
```

## 💡기타
<!-- 추가로 적고 싶은 내용을 모두 적어주세요 -->
