### PR TITLE
Feature/스터디-생성-수정-validation

### DIFF
--- a/src/components/StudyCreate&Edit/StudyLabelInput.tsx
+++ b/src/components/StudyCreate&Edit/StudyLabelInput.tsx
@@ -22,7 +22,6 @@ function StudyCreateLabelInput({
       fullWidth={fullWidth}
       value={value}
       onChange={onChange}
-      inputProps={{ maxLength: 50, minLength: 5 }}
     />
   );
 }

--- a/src/components/StudyCreate&Edit/StudyMultiLineInput.tsx
+++ b/src/components/StudyCreate&Edit/StudyMultiLineInput.tsx
@@ -27,8 +27,6 @@ function StudyCreateMultiLineInput({
         style: {
           height,
         },
-        maxLength: 1000,
-        minLength: 10,
       }}
       onChange={onChange}
       multiline

--- a/src/containers/StudyEdit/StudyEditForm.tsx
+++ b/src/containers/StudyEdit/StudyEditForm.tsx
@@ -111,8 +111,8 @@ function StudyEditForm() {
   return (
     <Formik
       initialValues={{
-        title: title,
-        description: description,
+        title,
+        description,
       }}
       enableReinitialize
       validationSchema={EditSchema}

--- a/src/containers/StudyEdit/StudyEditForm.tsx
+++ b/src/containers/StudyEdit/StudyEditForm.tsx
@@ -140,7 +140,7 @@ function StudyEditForm() {
               <StudyEditHeading>
                 <Typography variant='h4'>스터디 수정</Typography>
                 <InputWrapper>
-                  {formik.touched.title && formik.errors.title ? (
+                  {formik.touched.title && formik.errors.title && (
                     <ErrorMessage ref={titleRef}>
                       {(() => {
                         if (titleRef.current) {
@@ -152,7 +152,7 @@ function StudyEditForm() {
                         return formik.errors.title;
                       })()}
                     </ErrorMessage>
-                  ) : null}
+                  )}
                   <Field
                     as={LabelInput}
                     label='스터디명'
@@ -181,7 +181,7 @@ function StudyEditForm() {
               </StudyEditImageWrapper>
               <StudyDescriptionWrapper>
                 <Typography variant='h5'>상세 설명</Typography>
-                {formik.touched.description && formik.errors.description ? (
+                {formik.touched.description && formik.errors.description && (
                   <ErrorMessage ref={descriptionRef}>
                     {(() => {
                       if (descriptionRef.current && !titleRef.current) {
@@ -193,7 +193,7 @@ function StudyEditForm() {
                       return formik.errors.description;
                     })()}
                   </ErrorMessage>
-                ) : null}
+                )}
                 <Field
                   as={MultiLineInput}
                   id='description'

--- a/src/containers/StudyEdit/style.ts
+++ b/src/containers/StudyEdit/style.ts
@@ -14,6 +14,16 @@ export const StudyEditHeading = styled.div`
   gap: 2rem;
 `;
 
+export const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const ErrorMessage = styled.div`
+  color: #ef4444;
+`;
+
 export const StudyEditImageWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -21,7 +31,9 @@ export const StudyEditImageWrapper = styled.div`
 `;
 export const ImageContainer = styled.div`
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 `;
 
 export const ImageWrapper = styled.div`

--- a/src/containers/StudyEdit/style.ts
+++ b/src/containers/StudyEdit/style.ts
@@ -21,7 +21,7 @@ export const InputWrapper = styled.div`
 `;
 
 export const ErrorMessage = styled.div`
-  color: #ef4444;
+  color: ${({ theme }) => theme.palette.error.main};
 `;
 
 export const StudyEditImageWrapper = styled.div`


### PR DESCRIPTION
<!-- 
  PR 작성 시 해당 Issue 연결
  PR 이름: Feature/개발-완료-기능
  PR은 선착순 2명이 달면 수정해서 merge 
-->

## ⚙기능
<!-- 기능을 설명해주세요 -->
스터디 수정 페이지 Form validation 입니다.
/study/1/edit path에서 확인할 수 있습니다.

https://user-images.githubusercontent.com/66072832/182449623-dceefb71-a1a2-4b34-a149-3a8825429d47.mp4



## 📃구현 내용
<!-- 구현 내용을 작성해 주세요 -->
- Yup Schema를 통해 validation 조건을 작성
- Formik과 Yup을 통해 Form validation
  - 제목은 필수 값
  - 제목은 최소 5에서 최대 50자 제한
  - 이미지의 경우 File Size 검증
    - 파일의 최대 크기는 1MB
    - 업로드 가능한 파일 `image/jpg`, `image/jpeg`, `image/gif`, `image/png`
    - 파일 업로드는 Formik에서 지원하지 않아 handler 함수를 따로 구현 -> `onImageChange` 함수
    - 로컬 state에 file이 있는 경우만 FormData의 imageFile 필드로 추가
  - 본문은 필수 값
    - 본문은 최소 10에서 최대 1,000자 제한
  - 에러 메세지
    - validation 후 에러가 있는 곳에 에러 메세지 노출
    - 에러 메세지가 있는 위치로 scroll 이동

### 에러 메세지
에러 메세지는 figma에 따로 없어 임의대로 작성했습니다.
![1](https://user-images.githubusercontent.com/66072832/182446622-afad05fb-0d27-4bc5-848e-45fc98efcf50.png)
### button disabled
isSubmitting인 경우(API 요청) button을 disabled 처리했습니다(자주색 밑줄 표시한 버튼처럼).
![2](https://user-images.githubusercontent.com/66072832/182446626-e376ff60-2755-481d-a5cf-70d8d562ecbc.png)

form validation이 되고, submit이 되면 API로 날릴 FormData를 console.log()로 출력하게 해두었습니다.
## 💡기타
<!-- 추가로 적고 싶은 내용을 모두 적어주세요 -->
스터디 생성 Form validation 까지 구현할 계획이었으나 진행 상태가 더디고 Formik, Yup 활용, 에러 메세지 UI를 리뷰 받고 진행하고자 PR을 작성했습니다.