### PR TITLE
Feature/로그인-API-연동

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { getStorageItem } from '@src/utils/storage';
 
 const host = process.env.REACT_APP_API_ENDPOINT ?? 'http://localhost:3000';
 
@@ -12,9 +13,27 @@ const axiosInstance: AxiosInstance = axios.create({
   },
 });
 
+export const axiosAuthInstance: AxiosInstance = axios.create({
+  baseURL: API_ENDPOINT,
+  timeout: 5000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
 axiosInstance.interceptors.response.use(
   (response) => Promise.resolve(response),
   (error) => Promise.reject(error),
 );
+
+axiosAuthInstance.interceptors.request.use((config) => {
+  const token = getStorageItem('token', '');
+
+  if (config.headers && token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  return config;
+});
 
 export default axiosInstance;

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -14,7 +14,7 @@ export const login = async (id: number) => {
 };
 
 export const getAuthUser = async () => {
-  const { data } = await axiosInstance({
+  const { data } = await axiosAuthInstance({
     baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/auth',
     method: 'GET',

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,13 +1,10 @@
-import { isDev } from '@constants/nodeEnv';
 import axiosInstance from '@apis/axiosInstance';
 
 export const login = async (id: number) => {
   const { data } = await axiosInstance({
-    baseURL: isDev
-      ? 'http://localhost:3000'
-      : process.env.REACT_APP_API_ENDPOINT,
-    url: isDev ? '/mock/loginUser.json' : '/api/v1/login',
-    method: isDev ? 'GET' : 'POST',
+    baseURL: process.env.REACT_APP_API_ENDPOINT,
+    url: '/login',
+    method: 'POST',
     data: {
       id,
     },
@@ -18,10 +15,8 @@ export const login = async (id: number) => {
 
 export const getAuthUser = async () => {
   const { data } = await axiosInstance({
-    baseURL: isDev
-      ? 'http://localhost:3000'
-      : process.env.REACT_APP_API_ENDPOINT,
-    url: isDev ? '/mock/authUser.json' : '/api/v1/auth',
+    baseURL: process.env.REACT_APP_API_ENDPOINT,
+    url: '/auth',
     method: 'GET',
   });
 
@@ -30,8 +25,12 @@ export const getAuthUser = async () => {
 
 export const logout = async () => {
   const { data } = await axiosInstance({
-    url: '/api/v1/logout',
+    baseURL: process.env.REACT_APP_API_END_POINT,
+    url: '/logout',
     method: 'POST',
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    },
   });
 
   return data;

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -2,7 +2,7 @@ import axiosInstance from '@apis/axiosInstance';
 
 export const login = async (id: number) => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_END_POINT,
+    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/login',
     method: 'POST',
     data: {
@@ -15,7 +15,7 @@ export const login = async (id: number) => {
 
 export const getAuthUser = async () => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_END_POINT,
+    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/auth',
     method: 'GET',
   });
@@ -25,12 +25,9 @@ export const getAuthUser = async () => {
 
 export const logout = async () => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_END_POINT,
+    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/logout',
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('token')}`,
-    },
   });
 
   return data;

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,4 +1,4 @@
-import axiosInstance from '@apis/axiosInstance';
+import axiosInstance, { axiosAuthInstance } from '@apis/axiosInstance';
 
 export const login = async (id: number) => {
   const { data } = await axiosInstance({
@@ -24,7 +24,7 @@ export const getAuthUser = async () => {
 };
 
 export const logout = async () => {
-  const { data } = await axiosInstance({
+  const { data } = await axiosAuthInstance({
     baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/logout',
     method: 'POST',

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -2,7 +2,6 @@ import axiosInstance, { axiosAuthInstance } from '@apis/axiosInstance';
 
 export const login = async (id: number) => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/login',
     method: 'POST',
     data: {
@@ -15,7 +14,6 @@ export const login = async (id: number) => {
 
 export const getAuthUser = async () => {
   const { data } = await axiosAuthInstance({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/auth',
     method: 'GET',
   });
@@ -25,7 +23,6 @@ export const getAuthUser = async () => {
 
 export const logout = async () => {
   const { data } = await axiosAuthInstance({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
     url: '/api/v1/logout',
     method: 'POST',
   });

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -2,8 +2,8 @@ import axiosInstance from '@apis/axiosInstance';
 
 export const login = async (id: number) => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
-    url: '/login',
+    baseURL: process.env.REACT_APP_API_END_POINT,
+    url: '/api/v1/login',
     method: 'POST',
     data: {
       id,
@@ -15,8 +15,8 @@ export const login = async (id: number) => {
 
 export const getAuthUser = async () => {
   const { data } = await axiosInstance({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
-    url: '/auth',
+    baseURL: process.env.REACT_APP_API_END_POINT,
+    url: '/api/v1/auth',
     method: 'GET',
   });
 
@@ -26,7 +26,7 @@ export const getAuthUser = async () => {
 export const logout = async () => {
   const { data } = await axiosInstance({
     baseURL: process.env.REACT_APP_API_END_POINT,
-    url: '/logout',
+    url: '/api/v1/logout',
     method: 'POST',
     headers: {
       Authorization: `Bearer ${localStorage.getItem('token')}`,

--- a/src/constants/oauth.ts
+++ b/src/constants/oauth.ts
@@ -1,0 +1,2 @@
+export const googleUrl = '/oauth2/authorization/google';
+export const githubUrl = '/oauth2/authorization/github';

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -155,7 +155,7 @@ function NavigationHeader() {
                       <LoginButtonContainer>
                         <a
                           href={`${
-                            process.env.REACT_APP_API_END_POINT + googleUrl
+                            process.env.REACT_APP_API_ENDPOINT + googleUrl
                           }`}
                         >
                           <LoginButton
@@ -171,7 +171,7 @@ function NavigationHeader() {
                         </a>
                         <a
                           href={`${
-                            process.env.REACT_APP_API_END_POINT + googleUrl
+                            process.env.REACT_APP_API_ENDPOINT + googleUrl
                           }`}
                         >
                           <LoginButton

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -155,7 +155,7 @@ function NavigationHeader() {
                       <LoginButtonContainer>
                         <a
                           href={`${
-                            process.env.REACT_APP_OAUTH_URL + googleUrl
+                            process.env.REACT_APP_API_END_POINT + googleUrl
                           }`}
                         >
                           <LoginButton
@@ -171,7 +171,7 @@ function NavigationHeader() {
                         </a>
                         <a
                           href={`${
-                            process.env.REACT_APP_OAUTH_URL + googleUrl
+                            process.env.REACT_APP_API_END_POINT + googleUrl
                           }`}
                         >
                           <LoginButton

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -6,6 +6,7 @@ import { googleUrl } from '@src/constants/oauth';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
 import GoogleIcon from '@src/components/GoogleIcon/GoogleIcon';
 import GitHubIcon from '@src/components/GitHubIcon/GitHubIcon';
+import { logout } from '@src/apis/user';
 import {
   Avatar,
   ClickAwayListener,
@@ -63,7 +64,8 @@ function NavigationHeader() {
     handleModalClose();
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await logout();
     dispatch(logoutUser());
   };
 

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -66,6 +66,7 @@ function NavigationHeader() {
 
   const handleLogout = async () => {
     await logout();
+    localStorage.removeItem('token');
     dispatch(logoutUser());
   };
 

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useState } from 'react';
+import { removeStorageItem } from '@src/utils/storage';
 import { selectUser, logoutUser } from '@src/store/slices/user';
 import { googleUrl } from '@src/constants/oauth';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
@@ -66,7 +67,7 @@ function NavigationHeader() {
 
   const handleLogout = async () => {
     await logout();
-    localStorage.removeItem('token');
+    removeStorageItem('token');
     dispatch(logoutUser());
   };
 

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useState } from 'react';
 import { selectUser, logoutUser } from '@src/store/slices/user';
+import { googleUrl } from '@src/constants/oauth';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
 import GoogleIcon from '@src/components/GoogleIcon/GoogleIcon';
 import GitHubIcon from '@src/components/GitHubIcon/GitHubIcon';
@@ -149,7 +150,9 @@ function NavigationHeader() {
                       </Typography>
                       <LoginButtonContainer>
                         <a
-                          href={`${process.env.REACT_APP_API_HOST}/oauth2/authorization/google`}
+                          href={`${
+                            process.env.REACT_APP_OAUTH_URL + googleUrl
+                          }`}
                         >
                           <LoginButton
                             variant='outlined'
@@ -163,7 +166,9 @@ function NavigationHeader() {
                           </LoginButton>
                         </a>
                         <a
-                          href={`${process.env.REACT_APP_API_HOST}/oauth2/authorization/google`}
+                          href={`${
+                            process.env.REACT_APP_OAUTH_URL + googleUrl
+                          }`}
                         >
                           <LoginButton
                             variant='outlined'

--- a/src/containers/NavigationHeader/NavigationHeader.tsx
+++ b/src/containers/NavigationHeader/NavigationHeader.tsx
@@ -1,11 +1,10 @@
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useState } from 'react';
-import { selectUser, loginUser, logoutUser } from '@src/store/slices/user';
+import { selectUser, logoutUser } from '@src/store/slices/user';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
 import GoogleIcon from '@src/components/GoogleIcon/GoogleIcon';
 import GitHubIcon from '@src/components/GitHubIcon/GitHubIcon';
-import { login } from '@src/apis/user';
 import {
   Avatar,
   ClickAwayListener,
@@ -58,11 +57,9 @@ function NavigationHeader() {
     setIsModalOpen(false);
   };
 
-  const handleLogin = async () => {
+  const handleLogin = () => {
     handleMenuClose();
     handleModalClose();
-    const res = await login(1);
-    dispatch(loginUser(res.member));
   };
 
   const handleLogout = () => {
@@ -151,26 +148,34 @@ function NavigationHeader() {
                         로그인/회원가입
                       </Typography>
                       <LoginButtonContainer>
-                        <LoginButton
-                          variant='outlined'
-                          color='secondary'
-                          onClick={handleLogin}
+                        <a
+                          href={`${process.env.REACT_APP_API_HOST}/oauth2/authorization/google`}
                         >
-                          <GoogleIcon />
-                          <ButtonTextWrapper>
-                            구글 계정으로 계속하기
-                          </ButtonTextWrapper>
-                        </LoginButton>
-                        <LoginButton
-                          variant='outlined'
-                          color='secondary'
-                          onClick={handleLogin}
+                          <LoginButton
+                            variant='outlined'
+                            color='secondary'
+                            onClick={handleLogin}
+                          >
+                            <GoogleIcon />
+                            <ButtonTextWrapper>
+                              구글 계정으로 계속하기
+                            </ButtonTextWrapper>
+                          </LoginButton>
+                        </a>
+                        <a
+                          href={`${process.env.REACT_APP_API_HOST}/oauth2/authorization/google`}
                         >
-                          <GitHubIcon />
-                          <ButtonTextWrapper>
-                            깃허브 계정으로 계속하기
-                          </ButtonTextWrapper>
-                        </LoginButton>
+                          <LoginButton
+                            variant='outlined'
+                            color='secondary'
+                            onClick={handleLogin}
+                          >
+                            <GitHubIcon />
+                            <ButtonTextWrapper>
+                              깃허브 계정으로 계속하기
+                            </ButtonTextWrapper>
+                          </LoginButton>
+                        </a>
                       </LoginButtonContainer>
                     </ModalWrapper>
                   </ModalContainer>

--- a/src/containers/NavigationHeader/style.ts
+++ b/src/containers/NavigationHeader/style.ts
@@ -124,6 +124,7 @@ export const LoginButtonContainer = styled.div`
 export const LoginButton = styled(Button)`
   justify-content: start;
   padding: 0.75rem 1.25rem;
+  width: 100%;
 `;
 
 export const ButtonTextWrapper = styled.div`

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { selectFlashAlert } from '@store/slices/flashAlert';
 import { getStorageItem } from '@src/utils/storage';
-import { loginUser } from '@src/store/slices/user';
+import { loginUser, selectUser } from '@src/store/slices/user';
 import { getAuthUser } from '@src/apis/user';
 import { FlashAlert, NavigationHeader } from '@containers';
 
@@ -12,10 +12,11 @@ import { LayoutContainer } from './style';
 function Layout() {
   const state = useSelector(selectFlashAlert);
   const dispatch = useDispatch();
+  const user = useSelector(selectUser);
 
   useEffect(() => {
     const autoLogin = async () => {
-      if (!getStorageItem('token', '')) return;
+      if (!getStorageItem('token', '') || user.isLogin) return;
       const data = await getAuthUser();
       dispatch(loginUser(data));
     };

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,12 +1,27 @@
 import { Outlet } from 'react-router';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { useEffect } from 'react';
 import { selectFlashAlert } from '@store/slices/flashAlert';
+import { getStorageItem } from '@src/utils/storage';
+import { loginUser } from '@src/store/slices/user';
+import { getAuthUser } from '@src/apis/user';
 import { FlashAlert, NavigationHeader } from '@containers';
 
 import { LayoutContainer } from './style';
 
 function Layout() {
   const state = useSelector(selectFlashAlert);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const autoLogin = async () => {
+      if (!getStorageItem('token', '')) return;
+      const data = await getAuthUser();
+      dispatch(loginUser(data));
+    };
+
+    autoLogin();
+  }, []);
 
   return (
     <LayoutContainer>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,9 @@
 import { useLocation, useNavigate } from 'react-router';
+import { useDispatch } from 'react-redux';
 import { useEffect } from 'react';
+import { loginUser } from '@src/store/slices/user';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
+import { login } from '@src/apis/user';
 import { CircularProgress, Typography, useTheme } from '@mui/material';
 
 import { LoginContainer } from './style';
@@ -10,10 +13,19 @@ function Login() {
   const theme = useTheme();
   const navigate = useNavigate();
   const qs = new URLSearchParams(search);
-  const id = qs.get('id');
+  const id = Number(qs.get('id'));
+  const dispatch = useDispatch();
 
   const loginRequest = async () => {
-    console.log(id);
+    try {
+      const data = await login(id);
+      dispatch(loginUser(data.member));
+      localStorage.setItem('token', data.accesstoken);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      navigate('/', { replace: true });
+    }
   };
 
   useEffect(() => {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router';
 import { useDispatch } from 'react-redux';
 import { useEffect } from 'react';
+import { setStorageItem } from '@src/utils/storage';
 import { loginUser } from '@src/store/slices/user';
 import LogoIcon from '@src/components/LogoIcon/LogoIcon';
 import { login } from '@src/apis/user';
@@ -20,7 +21,7 @@ function Login() {
     try {
       const data = await login(id);
       dispatch(loginUser(data.member));
-      localStorage.setItem('token', data.accesstoken);
+      setStorageItem('token', data.accesstoken);
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,32 @@
+import { useLocation, useNavigate } from 'react-router';
+import { useEffect } from 'react';
+import LogoIcon from '@src/components/LogoIcon/LogoIcon';
+import { CircularProgress, Typography, useTheme } from '@mui/material';
+
+import { LoginContainer } from './style';
+
+function Login() {
+  const { search } = useLocation();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const qs = new URLSearchParams(search);
+  const id = qs.get('id');
+
+  const loginRequest = async () => {
+    console.log(id);
+  };
+
+  useEffect(() => {
+    loginRequest();
+  }, []);
+
+  return (
+    <LoginContainer>
+      <LogoIcon color={theme.palette.primary.main} />
+      <Typography variant='h3'>로그인 요청 중입니다.</Typography>
+      <CircularProgress color='primary' />
+    </LoginContainer>
+  );
+}
+
+export default Login;

--- a/src/pages/Login/style.ts
+++ b/src/pages/Login/style.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const LoginContainer = styled.div`
+  max-width: 640px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin: 0 auto;
+  padding: 15rem 0;
+`;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, BrowserRouter } from 'react-router-dom';
 import {
   COMMUNITY,
   HOME,
+  LOGIN,
   PROFILE_DETAIL,
   PROFILE_EDIT,
   SIGN_UP,
@@ -15,6 +16,7 @@ import StudyEdit from '@src/pages/StudyEdit';
 import StudyDetail from '@src/pages/StudyDetail';
 import StudyCreate from '@src/pages/StudyCreate';
 import SignUp from '@src/pages/SignUp';
+import Login from '@src/pages/Login';
 import Community from '@src/pages/Community';
 import Layout from '@src/layout/Layout';
 import { Home, NotFound, ProfileDetail, ProfileEdit } from '@pages';
@@ -34,6 +36,7 @@ function Routers() {
           <Route path={STUDY_MANAGE} element={<StudyManage />} />
           <Route path={SIGN_UP} element={<SignUp />} />
         </Route>
+        <Route path={LOGIN} element={<Login />} />
         <Route path='/*' element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/src/router/path.ts
+++ b/src/router/path.ts
@@ -7,3 +7,4 @@ export const STUDY_EDIT = '/study/:study_id/edit';
 export const PROFILE_DETAIL = '/user/:user_id';
 export const PROFILE_EDIT = '/user/:user_id/edit';
 export const SIGN_UP = '/sign-up';
+export const LOGIN = '/login';

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,28 @@
+const storage = window.localStorage;
+
+export const setStorageItem = (key: string, value: string) => {
+  try {
+    storage.setItem(key, value);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+export const getStorageItem = (key: string, defaultValue: string) => {
+  try {
+    const storedValue = storage.getItem(key);
+
+    if (!storedValue) {
+      return defaultValue;
+    }
+
+    return storedValue;
+  } catch (e) {
+    console.error(e);
+    return defaultValue;
+  }
+};
+
+export const removeStorageItem = (key: string) => {
+  storage.removeItem(key);
+};


### PR DESCRIPTION
<!-- 
  PR 작성 시 해당 Issue 연결
  PR 이름: Feature/개발-완료-기능
  PR은 선착순 2명이 달면 수정해서 merge 
-->

## ⚙기능
<!-- 기능을 설명해주세요 -->

- OAuth 로그인, 로그아웃 API 연동
- localStorage에 Token이 남아있는 경우 자동 로그인
- OAuth 로그인 처리를 위한 Login 페이지 구현
- 인증이 필요한 요청에 사용할 `axiosAuthInstance` 추가

<br><br>

## 📃구현 내용
<!-- 구현 내용을 작성해 주세요 -->
![OAuth_login_API](https://user-images.githubusercontent.com/62253743/183706254-a6e460db-baab-4d4c-a83f-58834562a68a.gif)

<br><br>

## 💡기타
<!-- 추가로 적고 싶은 내용을 모두 적어주세요 -->

- `request header`에 `token`을 담아서 보내야 하는 요청은 모두 `axiosAuthInstance`를 사용하시면 됩니다!

- `axiosAuthInstance`는 최대한 다른 파일을 변경시키지 않게 일단 export const로 처리해 두었습니다. 추후 리팩토링 할 때 `axiosInstance`의 `export default`를 제거하고 변경하면 될 것 같습니다!

- 아직 Access Token Refresh 관련 response interceptor는 구현되어있지 않습니다.

- 새로고침 후 자동 로그인이 진행되는 과정에서 네비게이션 헤더가 깜빡이는 현상이 있습니다. 관련해서 코멘트 남겨주시면 감사하겠습니다!


