### PR TITLE
Feature/스터디-생성-페이지-API-Alert

### DIFF
--- a/src/apis/studyCreate.ts
+++ b/src/apis/studyCreate.ts
@@ -1,0 +1,19 @@
+import axiosInstance from './axiosInstance';
+
+const API_END_POINT = process.env.REACT_APP_API_ENDPOINT;
+const token = process.env.REACT_APP_TEST_TOKEN;
+
+export const createNewStudy = async (formData: FormData) => {
+  const { data } = await axiosInstance({
+    baseURL: API_END_POINT,
+    url: '/study-groups',
+    method: 'POST',
+    data: formData,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return data;
+};

--- a/src/apis/studyCreate.ts
+++ b/src/apis/studyCreate.ts
@@ -1,17 +1,15 @@
-import axiosInstance from './axiosInstance';
+import { axiosAuthInstance } from './axiosInstance';
 
 const API_END_POINT = process.env.REACT_APP_API_ENDPOINT;
-const token = process.env.REACT_APP_TEST_TOKEN;
 
 export const createNewStudy = async (formData: FormData) => {
-  const { data } = await axiosInstance({
+  const { data } = await axiosAuthInstance({
     baseURL: API_END_POINT,
-    url: '/study-groups',
+    url: '/api/v1/study-groups',
     method: 'POST',
     data: formData,
     headers: {
       'Content-Type': 'multipart/form-data',
-      Authorization: `Bearer ${token}`,
     },
   });
 

--- a/src/components/StudyCreate&Edit/StudyLabelInput.tsx
+++ b/src/components/StudyCreate&Edit/StudyLabelInput.tsx
@@ -9,6 +9,7 @@ interface Props {
   error?: boolean;
   helperText?: string | false | undefined;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  autoFocus?: boolean;
 }
 
 function StudyCreateLabelInput({
@@ -20,6 +21,7 @@ function StudyCreateLabelInput({
   error,
   helperText,
   onChange,
+  autoFocus,
 }: Props) {
   return (
     <TextField
@@ -31,6 +33,7 @@ function StudyCreateLabelInput({
       error={error}
       helperText={helperText}
       onChange={onChange}
+      autoFocus={autoFocus}
     />
   );
 }

--- a/src/components/StudyCreate/StudyCreateRangeDatePicker/StudyCreateRangeDatePicker.tsx
+++ b/src/components/StudyCreate/StudyCreateRangeDatePicker/StudyCreateRangeDatePicker.tsx
@@ -23,10 +23,10 @@ function StudyCreateRangeDatePicker({
   const diffDays = moment.duration(startDate.diff(moment())).asDays() + 1;
 
   useEffect(() => {
-    getStartValue(startDate.format('YYYY-MM-DD hh:mm:ss'));
+    getStartValue(startDate.format('YYYY-MM-DD HH:mm:ss'));
   }, [startDate]);
   useEffect(() => {
-    getEndValue(endDate.format('YYYY-MM-DD hh:mm:ss'));
+    getEndValue(endDate.format('YYYY-MM-DD HH:mm:ss'));
   }, [endDate]);
 
   return (

--- a/src/containers/StudyCreateForm/StudyCreateForm.tsx
+++ b/src/containers/StudyCreateForm/StudyCreateForm.tsx
@@ -202,7 +202,7 @@ function StudyCreateFormContainer() {
     try {
       const res = await createNewStudy(formData);
       const { studyGroupId } = res;
-      console.log(studyGroupId);
+
       navigate(`/study/${studyGroupId}`, { replace: true });
       return res;
     } catch (error) {
@@ -256,13 +256,6 @@ function StudyCreateFormContainer() {
 
         const formData = createFormData(values);
         createStudy(formData);
-
-        setTimeout(() => {
-          for (const key of formData.keys()) {
-            console.log(key, ':', formData.get(key));
-          }
-          actions.setSubmitting(false);
-        }, 3000);
       }}
     >
       {({

--- a/src/containers/StudyCreateForm/StudyCreateForm.tsx
+++ b/src/containers/StudyCreateForm/StudyCreateForm.tsx
@@ -186,7 +186,6 @@ function StudyCreateFormContainer() {
     formData.append('topic', topic);
     formData.append('isOnline', isOnline === 'online' ? 'true' : 'false');
     if (isOnline === 'offline') formData.append('region', region);
-    //formData.append('region', isOnline === 'online' ? '' : region);
     formData.append('numberOfRecruits', numberOfRecruits);
     formData.append('startDateTime', startDate);
     formData.append('endDateTime', endDate);


### PR DESCRIPTION
<!-- 
  PR 작성 시 해당 Issue 연결
  PR 이름: Feature/개발-완료-기능
  PR은 선착순 2명이 달면 수정해서 merge 
-->

## ⚙기능
<!-- 기능을 설명해주세요 -->
- ### 스터디 생성 요청 API를 추가합니다.
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/66072832/183717354-0b4c7e03-72e4-432f-aedc-76895d11a5ec.gif)
- ### 스터디 생성 요청 시 에러 alert 추가
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/66072832/183717404-b2010d24-bbc0-48aa-9fee-23161968aa1d.gif)

## 📃구현 내용
<!-- 구현 내용을 작성해 주세요 -->
### 스터디 생성 요청 API 881770cbc25d4de0be73184085ffd0c8dc23b3c4 0ee254ad603a90615541971bfe4c06d5b90e3aeb
multipart/form-data로 가공된 form data를 전송해 요청이 성공하면 해당 스터디 id로 이동 시키도록 되어있습니다.
- 선호 MBTI의 경우 stringify 처리된 배열 형태를 넘기는 것에서 join()으로 넘기는 것으로 수정했습니다.
- Range Date Picker 컴포넌트에서 시간 format이 `hh:mm:ss`로 지정되어 에러가 발생해 `HH:mm:ss` 형태의 24시간제로 수정했습니다. 0ad00b820ff6588117a44042c8ed7949348bc7ae

### autofocus, alert 4dd586e24a790f75e442f6932fb770ce700dd053 e3dddba74476280623fdd2b49813cd5395daba37
진입 시 제목 input에 auto focus 지정했습니다.

alert은 패드님이 작성해주신 alert 활용했습니다.
form validation을 통해 helperText를 지정했지만 스크롤 이동을 삭제 한 후 UI적으로 필요하다고 생각해 추가했습니다.
form values 중 일부 필드(제목, 분야, 오프라인일 경우 지역, 인원, 설명)가 빈 값일 때 alert을 노출하도록 해두었습니다.
## 💡기타
<!-- 추가로 적고 싶은 내용을 모두 적어주세요 -->
.env 파일에 test용 access token을 가져와 headers에 담아 사용하고 있습니다. 테스트 해보실 때 확인 해주세요!
맥키님이 만드신 PR merge되고 token이 저장되면 해당 부분은 수정할 계획입니다!